### PR TITLE
Remove reference to Sheffield

### DIFF
--- a/source/for-housing-associations.html.erb
+++ b/source/for-housing-associations.html.erb
@@ -16,7 +16,7 @@ title: Light House
     <div class="col-3 colophon">
       <p>Light House is a collaboration between Green Quarter Community Energy Co-op and the Co-operative Group. Our mission is to accelerate Britain's transition to sustainable energy, controlled by its communities.</p>
 
-      <p>Green Quarter Community Energy Co-op is a community-owned social enterprise that develops and runs solar and hydroelectric generators in Sheffield.</p>
+      <p>Green Quarter Community Energy Co-op is a community-owned social enterprise that develops and runs solar generation in Manchester.</p>
     </div>
     <div class="col-9 proposition">
       <h2>LED lighting typically saves households £2-3 a&nbsp;week</h2>


### PR DESCRIPTION
Changed the description of the community energy group to replace
Sheffield with Manchester.